### PR TITLE
Add data source fetcher implementations

### DIFF
--- a/data_sources/alt_data_fetcher.py
+++ b/data_sources/alt_data_fetcher.py
@@ -1,0 +1,39 @@
+# data_sources/alt_data_fetcher.py
+
+"""Fetch alternative business data such as web traffic or job postings."""
+
+from typing import Any, Dict, Optional
+from datetime import datetime
+
+import requests
+
+from config.env_loader import load_env
+
+
+class AltDataFetcher:
+    """Gather alternative data using external APIs."""
+
+    def __init__(self):
+        self.config = load_env()
+        self.api_key = self.config.get("SIMILARWEB_API_KEY", "")
+
+    def fetch_web_traffic(self, domain: str) -> Optional[Dict[str, Any]]:
+        """Fetch monthly visits from SimilarWeb."""
+        if not self.api_key:
+            print("[AltDataFetcher] Missing SIMILARWEB_API_KEY")
+            return None
+        url = (
+            f"https://api.similarweb.com/v1/website/{domain}/total-traffic-and-engagement/visits"
+        )
+        params = {
+            "api_key": self.api_key,
+            "start_date": datetime.now().strftime("%Y-%m"),
+            "granularity": "monthly",
+        }
+        try:
+            resp = requests.get(url, params=params, timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            print(f"[AltDataFetcher] Error fetching traffic for {domain}: {exc}")
+            return None

--- a/data_sources/insider_data_fetcher.py
+++ b/data_sources/insider_data_fetcher.py
@@ -1,0 +1,30 @@
+# data_sources/insider_data_fetcher.py
+
+"""Fetch insider trading information using OpenInsider."""
+
+from typing import List, Dict, Optional
+import csv
+import io
+
+import requests
+
+from config.env_loader import load_env
+
+
+class InsiderDataFetcher:
+    """Retrieve insider trading activity."""
+
+    def __init__(self):
+        self.config = load_env()
+
+    def fetch_insider_trades(self, ticker: str) -> Optional[List[Dict[str, str]]]:
+        url = f"https://openinsider.com/screener?s={ticker}&output=1"
+        try:
+            resp = requests.get(url, timeout=10)
+            resp.raise_for_status()
+            csv_data = resp.text
+            reader = csv.DictReader(io.StringIO(csv_data))
+            return list(reader)
+        except Exception as exc:
+            print(f"[InsiderDataFetcher] Error fetching trades for {ticker}: {exc}")
+            return None

--- a/data_sources/macro_fetcher.py
+++ b/data_sources/macro_fetcher.py
@@ -1,0 +1,41 @@
+# data_sources/macro_fetcher.py
+
+"""Fetch macroeconomic indicators from the FRED API."""
+
+from typing import Optional, Dict
+import requests
+import pandas as pd
+
+from config.env_loader import load_env
+
+
+class MacroFetcher:
+    """Retrieve macroeconomic data such as CPI or unemployment rates."""
+
+    def __init__(self):
+        self.config = load_env()
+        self.api_key = self.config.get("FRED_API_KEY", "")
+
+    def fetch_series(self, series_id: str) -> Optional[pd.DataFrame]:
+        if not self.api_key:
+            print("[MacroFetcher] Missing FRED_API_KEY")
+            return None
+        url = "https://api.stlouisfed.org/fred/series/observations"
+        params = {
+            "series_id": series_id,
+            "api_key": self.api_key,
+            "file_type": "json",
+        }
+        try:
+            resp = requests.get(url, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json().get("observations", [])
+            return pd.DataFrame(data)
+        except Exception as exc:
+            print(f"[MacroFetcher] Error fetching series {series_id}: {exc}")
+            return None
+
+    def snapshot(self) -> Dict[str, Optional[pd.DataFrame]]:
+        """Return a dictionary of commonly used macro series."""
+        series = ["CPIAUCSL", "UNRATE", "GDP", "DGS10"]
+        return {sid: self.fetch_series(sid) for sid in series}

--- a/data_sources/news_fetcher.py
+++ b/data_sources/news_fetcher.py
@@ -1,0 +1,47 @@
+# data_sources/news_fetcher.py
+
+"""Fetch recent news headlines for a ticker using the NewsAPI service."""
+
+from datetime import datetime, timedelta
+from typing import List, Dict, Optional
+
+import requests
+
+from config.env_loader import load_env
+
+
+class NewsFetcher:
+    """Retrieve news headlines for specific tickers."""
+
+    BASE_URL = "https://newsapi.org/v2/everything"
+
+    def __init__(self):
+        self.config = load_env()
+        self.api_key = self.config.get("NEWS_API_KEY", "")
+
+    def fetch(self, query: str, days: int = 3) -> Optional[List[Dict[str, str]]]:
+        if not self.api_key:
+            print("[NewsFetcher] Missing NEWS_API_KEY")
+            return None
+        params = {
+            "q": query,
+            "from": (datetime.utcnow() - timedelta(days=days)).strftime("%Y-%m-%d"),
+            "sortBy": "publishedAt",
+            "apiKey": self.api_key,
+            "language": "en",
+        }
+        try:
+            resp = requests.get(self.BASE_URL, params=params, timeout=10)
+            resp.raise_for_status()
+            articles = resp.json().get("articles", [])
+            return [
+                {
+                    "title": art.get("title"),
+                    "url": art.get("url"),
+                    "publishedAt": art.get("publishedAt"),
+                }
+                for art in articles
+            ]
+        except Exception as exc:
+            print(f"[NewsFetcher] Error fetching news for {query}: {exc}")
+            return None

--- a/data_sources/options_data_fetcher.py
+++ b/data_sources/options_data_fetcher.py
@@ -1,0 +1,51 @@
+# data_sources/options_data_fetcher.py
+
+"""Fetch options market data to detect unusual activity."""
+
+from typing import Any, Dict, Optional
+from datetime import datetime
+
+import requests
+
+from config.env_loader import load_env
+
+
+class OptionsDataFetcher:
+    """Retrieve options flow information using the Tradier API."""
+
+    BASE_URL = "https://api.tradier.com/v1/markets/options"
+
+    def __init__(self):
+        self.config = load_env()
+        self.api_key = self.config.get("TRADIER_API_KEY", "")
+
+    def _headers(self) -> Dict[str, str]:
+        return {"Authorization": f"Bearer {self.api_key}", "Accept": "application/json"}
+
+    def fetch_chains(self, ticker: str, expiration: str) -> Optional[Dict[str, Any]]:
+        if not self.api_key:
+            print("[OptionsDataFetcher] Missing TRADIER_API_KEY")
+            return None
+        url = f"{self.BASE_URL}/chains"
+        params = {"symbol": ticker, "expiration": expiration}
+        try:
+            resp = requests.get(url, params=params, headers=self._headers(), timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            print(f"[OptionsDataFetcher] Error fetching chains for {ticker}: {exc}")
+            return None
+
+    def fetch_expirations(self, ticker: str) -> Optional[Dict[str, Any]]:
+        if not self.api_key:
+            print("[OptionsDataFetcher] Missing TRADIER_API_KEY")
+            return None
+        url = f"{self.BASE_URL}/expirations"
+        params = {"symbol": ticker}
+        try:
+            resp = requests.get(url, params=params, headers=self._headers(), timeout=10)
+            resp.raise_for_status()
+            return resp.json()
+        except Exception as exc:
+            print(f"[OptionsDataFetcher] Error fetching expirations for {ticker}: {exc}")
+            return None

--- a/data_sources/sector_etf_tracker.py
+++ b/data_sources/sector_etf_tracker.py
@@ -1,0 +1,22 @@
+# data_sources/sector_etf_tracker.py
+
+"""Track performance of sector ETFs using yfinance."""
+
+from typing import Dict, List, Optional
+
+import pandas as pd
+import yfinance as yf
+
+
+class SectorETFTracker:
+    """Fetch historical sector ETF prices and compute returns."""
+
+    @staticmethod
+    def fetch_returns(etfs: List[str], period: str = "3mo") -> Optional[pd.DataFrame]:
+        try:
+            data = yf.download(etfs, period=period, interval="1d", progress=False)["Adj Close"]
+            returns = data.pct_change().dropna()
+            return returns
+        except Exception as exc:
+            print(f"[SectorETFTracker] Error fetching data: {exc}")
+            return None

--- a/data_sources/social_sentiment_fetcher.py
+++ b/data_sources/social_sentiment_fetcher.py
@@ -1,0 +1,29 @@
+# data_sources/social_sentiment_fetcher.py
+
+"""Collect social media posts from Reddit using Pushshift."""
+
+from typing import List, Dict, Optional
+import requests
+
+from config.env_loader import load_env
+
+
+class SocialSentimentFetcher:
+    """Fetch recent social media mentions."""
+
+    BASE_URL = "https://api.pushshift.io/reddit/search/comment/"
+
+    def __init__(self):
+        self.config = load_env()
+
+    def fetch_reddit_comments(self, query: str, limit: int = 100) -> Optional[List[Dict[str, str]]]:
+        params = {"q": query, "size": limit}
+        try:
+            resp = requests.get(self.BASE_URL, params=params, timeout=10)
+            resp.raise_for_status()
+            data = resp.json().get("data", [])
+            return [{"body": item.get("body"), "created_utc": item.get("created_utc")}
+                    for item in data]
+        except Exception as exc:
+            print(f"[SocialSentimentFetcher] Error fetching reddit data: {exc}")
+            return None

--- a/data_sources/stock_data_fetcher.py
+++ b/data_sources/stock_data_fetcher.py
@@ -1,0 +1,34 @@
+# data_sources/stock_data_fetcher.py
+
+"""Utilities for fetching OHLCV data for stocks using yfinance."""
+
+from typing import Optional
+
+import pandas as pd
+import yfinance as yf
+
+from config.env_loader import load_env
+
+
+class StockDataFetcher:
+    """Fetch OHLCV price and volume data for tickers."""
+
+    def __init__(self):
+        self.config = load_env()
+
+    def fetch_ohlcv(
+        self,
+        ticker: str,
+        period: str = "1mo",
+        interval: str = "1d",
+    ) -> Optional[pd.DataFrame]:
+        """Return OHLCV data for ``ticker`` or ``None`` on failure."""
+        try:
+            data = yf.download(ticker, period=period, interval=interval, progress=False)
+            if data.empty:
+                print(f"[StockDataFetcher] No data for {ticker}")
+                return None
+            return data
+        except Exception as exc:
+            print(f"[StockDataFetcher] Error fetching {ticker}: {exc}")
+            return None

--- a/data_sources/technical_analysis.py
+++ b/data_sources/technical_analysis.py
@@ -1,0 +1,51 @@
+# data_sources/technical_analysis.py
+
+"""Basic technical indicator calculations using pandas."""
+
+from typing import Dict
+
+import pandas as pd
+
+
+class TechnicalAnalysis:
+    """Compute common technical indicators from OHLCV data."""
+
+    @staticmethod
+    def sma(data: pd.Series, period: int = 20) -> pd.Series:
+        return data.rolling(window=period).mean()
+
+    @staticmethod
+    def rsi(data: pd.Series, period: int = 14) -> pd.Series:
+        delta = data.diff()
+        gain = (delta.where(delta > 0, 0)).rolling(period).mean()
+        loss = (-delta.where(delta < 0, 0)).rolling(period).mean()
+        rs = gain / loss
+        return 100 - (100 / (1 + rs))
+
+    @staticmethod
+    def macd(data: pd.Series) -> pd.DataFrame:
+        exp1 = data.ewm(span=12, adjust=False).mean()
+        exp2 = data.ewm(span=26, adjust=False).mean()
+        macd = exp1 - exp2
+        signal = macd.ewm(span=9, adjust=False).mean()
+        hist = macd - signal
+        return pd.DataFrame({'macd': macd, 'signal': signal, 'hist': hist})
+
+    @staticmethod
+    def bollinger_bands(data: pd.Series, period: int = 20, std_dev: int = 2) -> pd.DataFrame:
+        sma = data.rolling(window=period).mean()
+        std = data.rolling(window=period).std()
+        upper = sma + std_dev * std
+        lower = sma - std_dev * std
+        return pd.DataFrame({'upper': upper, 'sma': sma, 'lower': lower})
+
+    @classmethod
+    def compute_all(cls, df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+        close = df['Close']
+        indicators = {
+            'sma_20': cls.sma(close, 20),
+            'rsi_14': cls.rsi(close, 14),
+            'macd': cls.macd(close),
+            'bollinger': cls.bollinger_bands(close, 20, 2),
+        }
+        return indicators


### PR DESCRIPTION
## Summary
- implement StockDataFetcher for OHLCV price data
- add technical indicator functions
- add AltDataFetcher for web traffic stats
- add InsiderDataFetcher for insider transactions
- create MacroFetcher for FRED series
- implement NewsFetcher for NewsAPI headlines
- implement OptionsDataFetcher for Tradier
- implement SectorETFTracker for ETF returns
- implement SocialSentimentFetcher for reddit comments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7a4791d8832ab280b585499b38ae